### PR TITLE
ProboCI/probo#201: Add missing rsync package needed for Drupal Probo plugin drush make options.

### DIFF
--- a/18.04/php7.3/Dockerfile
+++ b/18.04/php7.3/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Image: proboci/ubuntu
 # Tag: 18.04-php7.3
-# 
+#
 # The default Node.js version on this build is 12.18.0
 # The npm package is v6.14.4 as updated as part of NodeJS 12.
 #
@@ -52,7 +52,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   g++ \
   make \
   cpanminus \
-  lsof
+  lsof \
+  rsync
 
 # Install apt packages for LAMP, varnish, npm, ruby, and all other tools available from apt.
 COPY files/mysql-setup.sql /mysql-setup.sql
@@ -104,7 +105,7 @@ RUN apt-get install -y mysql-server \
   && mysql -uroot < /mysql-setup.sql \
   && service mysql stop \
   && service varnish stop \
-  && rm -rf /tmp/* /mysql-setup.sql 
+  && rm -rf /tmp/* /mysql-setup.sql
 
 # Install composer and drush.
 RUN mkdir /usr/local/src/drush9


### PR DESCRIPTION
Related to ProboCI/probo#201.

ProboCI configs using the drush make options available in the Drupal ProboCI plugin because they [rely on rsync](https://github.com/ProboCI/probo/blob/master/lib/plugins/TaskRunner/Drupal.js#L272) which is not installed on the latest docker images.

rsync was installed in the old ubuntu 14/16 images.  See the comparison below.

```
$ docker run -t -i --rm proboci/ubuntu:18.04-php7.3 /bin/bash
Unable to find image 'proboci/ubuntu:18.04-php7.3' locally
18.04-php7.3: Pulling from proboci/ubuntu
d519e2592276: Pull complete 
d22d2dfcfa9c: Pull complete 
b3afe92c540b: Pull complete 
0d24d47b0118: Pull complete 
Digest: sha256:0552b511cee5af35f37e31375aba87ef4497a610199291c89c4be6146412b418
Status: Downloaded newer image for proboci/ubuntu:18.04-php7.3
root@2b3dcef36cf6:~# command -v rsync
root@2b3dcef36cf6:~# command -v php  
/usr/bin/php
root@2b3dcef36cf6:~# command -v drush
root@2b3dcef36cf6:~# exit
exit

$ docker run -t -i --rm proboci/ubuntu-16.04-lamp:php-7.2 /bin/bash
Unable to find image 'proboci/ubuntu-16.04-lamp:php-7.2' locally
php-7.2: Pulling from proboci/ubuntu-16.04-lamp
18d680d61657: Pull complete 
0addb6fece63: Pull complete 
78e58219b215: Pull complete 
eb6959a66df2: Pull complete 
2953571f7793: Pull complete 
Digest: sha256:9b7c292022f51347afd0cb6382521ee1fe9b86832b76a66def9fae03bed048e0
Status: Downloaded newer image for proboci/ubuntu-16.04-lamp:php-7.2
root@24280a30ca84:/# command -v rsync
/usr/bin/rsync
root@24280a30ca84:/# command -v php  
/usr/bin/php
root@24280a30ca84:/# command -v drush
/usr/local/bin/drush
root@24280a30ca84:/# exit
exit
```
